### PR TITLE
Debug web map display and location

### DIFF
--- a/lib/features/emergency/presentation/emergency_providers_screen.dart
+++ b/lib/features/emergency/presentation/emergency_providers_screen.dart
@@ -2,6 +2,9 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:zippup/features/profile/presentation/provider_profile_screen.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter_map/flutter_map.dart' as lm;
+import 'package:latlong2/latlong.dart' as ll;
 import 'package:geolocator/geolocator.dart' as geo;
 import 'package:zippup/services/location/location_service.dart';
 
@@ -102,6 +105,21 @@ class _EmergencyProvidersScreenState extends State<EmergencyProvidersScreen> {
 							child: Builder(builder: (context) {
 								if (center == null) return const Center(child: Text('Map: no location yet'));
 								try {
+									if (kIsWeb) {
+										final fmMarkers = markers.map<lm.Marker>((m) => lm.Marker(
+											point: ll.LatLng(m.position.latitude, m.position.longitude),
+											width: 40,
+											height: 40,
+											child: const Icon(Icons.location_on, color: Colors.redAccent),
+										)).toList();
+										return lm.FlutterMap(
+											options: lm.MapOptions(initialCenter: ll.LatLng(center!.latitude, center!.longitude), initialZoom: 12),
+											children: [
+												lm.TileLayer(urlTemplate: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', subdomains: const ['a','b','c']),
+												lm.MarkerLayer(markers: fmMarkers),
+											],
+										);
+									}
 									return GoogleMap(
 										initialCameraPosition: CameraPosition(target: center!, zoom: 12),
 										markers: markers,

--- a/lib/features/food/presentation/vendor_list_screen.dart
+++ b/lib/features/food/presentation/vendor_list_screen.dart
@@ -2,6 +2,9 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter_map/flutter_map.dart' as lm;
+import 'package:latlong2/latlong.dart' as ll;
 import 'package:geolocator/geolocator.dart' as geo;
 import 'package:zippup/services/location/location_service.dart';
 
@@ -91,6 +94,21 @@ class _VendorListScreenState extends State<VendorListScreen> {
 							child: Builder(builder: (context) {
 								if (center == null) return const Center(child: Text('Map: no location yet'));
 								try {
+									if (kIsWeb) {
+										final fmMarkers = markers.map<lm.Marker>((m) => lm.Marker(
+											point: ll.LatLng(m.position.latitude, m.position.longitude),
+											width: 40,
+											height: 40,
+											child: const Icon(Icons.location_on, color: Colors.redAccent),
+										)).toList();
+										return lm.FlutterMap(
+											options: lm.MapOptions(initialCenter: ll.LatLng(center!.latitude, center!.longitude), initialZoom: 12),
+											children: [
+												lm.TileLayer(urlTemplate: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', subdomains: const ['a','b','c']),
+												lm.MarkerLayer(markers: fmMarkers),
+											],
+										);
+									}
 									return GoogleMap(initialCameraPosition: CameraPosition(target: center!, zoom: 12), markers: markers, myLocationEnabled: false, compassEnabled: false);
 								} catch (_) {
 									return const Center(child: Text('Map failed to load'));

--- a/lib/features/navigation/map_booking_screen.dart
+++ b/lib/features/navigation/map_booking_screen.dart
@@ -17,11 +17,16 @@ class _MapBookingScreenState extends State<MapBookingScreen> {
 	GoogleMapController? _mapController;
 	bool _isTracking = false;
 
+	void _onMarkersUpdate() {
+		if (mounted) setState(() {});
+	}
+
 	@override
 	void initState() {
 		super.initState();
 		_init();
 		_mapService.currentLocationNotifier.addListener(_onLocationUpdate);
+		_mapService.markersNotifier.addListener(_onMarkersUpdate);
 	}
 
 	void _onLocationUpdate() {
@@ -230,6 +235,7 @@ class _MapBookingScreenState extends State<MapBookingScreen> {
 	void dispose() {
 		_mapController?.dispose();
 		_mapService.currentLocationNotifier.removeListener(_onLocationUpdate);
+		_mapService.markersNotifier.removeListener(_onMarkersUpdate);
 		_mapService.dispose();
 		super.dispose();
 	}

--- a/web/index.html
+++ b/web/index.html
@@ -12,7 +12,7 @@
   <!-- Google Maps API key for web (let google_maps_flutter load the script) -->
   <meta name="google_maps_api_key" content="AIzaSyB2ICHPlMoU-r2HohidWifZp6WFe9jvFd8">
   <!-- Use HTML renderer for stable Maps rendering -->
-  <meta name="flutter-web-renderer" content="canvaskit">
+  <meta name="flutter-web-renderer" content="html">
 
   <!-- iOS meta tags & icons -->
   <meta name="mobile-web-app-capable" content="yes">


### PR DESCRIPTION
Fix web white screen, enable map tile rendering, and show current location on web.

The web app was stuck on a white screen due to CanvasKit renderer issues. Google Maps Flutter does not fully support web, leading to empty map tiles. The current location marker was also not appearing because the UI was not being rebuilt when the marker data changed. These changes address these specific web platform incompatibilities and rendering issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-24016f2a-7c96-4b53-bd93-ad0a8d427668">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-24016f2a-7c96-4b53-bd93-ad0a8d427668">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

