### PR TITLE
Fix rider and driver profile issues

### DIFF
--- a/lib/features/transport/presentation/driver_ride_nav_screen.dart
+++ b/lib/features/transport/presentation/driver_ride_nav_screen.dart
@@ -436,6 +436,30 @@ class _DriverRideNavScreenState extends State<DriverRideNavScreen> {
 							child: Column(
 								crossAxisAlignment: CrossAxisAlignment.stretch,
 								children: [
+									if (ride.riderId.isNotEmpty && (ride.status == RideStatus.accepted || ride.status == RideStatus.arriving || ride.status == RideStatus.arrived || ride.status == RideStatus.enroute))
+										Card(
+											child: FutureBuilder<List<dynamic>>(
+												future: Future.wait([
+													FirebaseFirestore.instance.collection('public_profiles').doc(ride.riderId).get(const GetOptions(source: Source.server)),
+													FirebaseFirestore.instance.collection('users').doc(ride.riderId).get(const GetOptions(source: Source.server)),
+												]),
+												builder: (context, s) {
+													final pu = (s.data != null && s.data!.isNotEmpty) ? ((s.data![0] as DocumentSnapshot<Map<String, dynamic>>?)?.data() ?? const {}) : const {};
+													final u = (s.data != null && s.data!.length > 1) ? ((s.data![1] as DocumentSnapshot<Map<String, dynamic>>?)?.data() ?? const {}) : const {};
+													String name = 'Customer';
+													if ((pu['name'] ?? '').toString().trim().isNotEmpty) name = pu['name'].toString().trim();
+													else if ((u['name'] ?? '').toString().trim().isNotEmpty) name = u['name'].toString().trim();
+													String photo = '';
+													if ((pu['photoUrl'] ?? '').toString().trim().isNotEmpty) photo = pu['photoUrl'].toString().trim();
+													else if ((u['photoUrl'] ?? '').toString().trim().isNotEmpty) photo = u['photoUrl'].toString().trim();
+													return ListTile(
+														leading: CircleAvatar(backgroundImage: photo.isNotEmpty ? NetworkImage(photo) : null, child: photo.isEmpty ? const Icon(Icons.person) : null),
+														title: Text(name),
+														subtitle: Text('Passenger • ${ride.type.name.toUpperCase()}'),
+													);
+												},
+											),
+										),
 									Row(children: [
 										Expanded(child: FilledButton.icon(
 											onPressed: (driverLat != null && driverLng != null && destLat != null && destLng != null)


### PR DESCRIPTION
Display rider's profile details on the driver's navigation screen to fix the bug where drivers saw their own profile instead of the passenger's.

---
<a href="https://cursor.com/background-agent?bcId=bc-be4738f3-7434-4eaa-bc51-9db2fd33f3bc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-be4738f3-7434-4eaa-bc51-9db2fd33f3bc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

